### PR TITLE
Added pinging for identifying a dead socket

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,9 @@ I wrote this so I could trigger home automation events based on what Xbmc is pla
 
 This also works for RasPlex (and Plex home theathre), but you need to manually configure the TCP control endpoint to listen on all interfaces (only localhost by default), by manually editing:
 
-~/.plexht/userdata/guisettings.xml
+`~/.plexht/userdata/guisettings.xml`
 
-find the node <esallinterfaces> and set the value to true.
+find the node `<esallinterfaces>` and set the value to true.
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,12 @@ A node.js module to listen for Xbmc events (notifications) and do stuff when the
 
 I wrote this so I could trigger home automation events based on what Xbmc is playing: turn on AVR to the Xbmc input when anything is playing, turn on TV to the Xbmc input when video is playing et c.
 
+This also works for RasPlex (and Plex home theathre), but you need to manually configure the TCP control endpoint to listen on all interfaces (only localhost by default), by manually editing:
+
+~/.plexht/userdata/guisettings.xml
+
+find the node <esallinterfaces> and set the value to true.
+
 ## Installation
 
 ```


### PR DESCRIPTION
Hi, I used your code for triggering a reconfiguration of my Sonos system when playback is started in Rasplex, works great!

However, since it never sends anything over the socket, a crash or a reboot of my plex client doesn't trigger any error, so I implemented the ping functionality of the JSONRPC which would trigger a socket error if the endpoint has vanished.

I saw the other pull request, and I tried it, but EverSocket doesn't seem like the solution here. It was even worse, since it would identify an error and reconnect constantly. 
